### PR TITLE
Add more space above the homepage portrait.

### DIFF
--- a/src/lib/views/ContactSection.svelte
+++ b/src/lib/views/ContactSection.svelte
@@ -428,7 +428,7 @@
     on:pointerleave={onLeave}
     on:click={onClick}
     data-cursor-field={radius}
-    class="portrait mt-14 md:mt-16"
+    class="portrait mt-20 md:mt-24"
     style="font-size: {sizeCss}"
     role="img"
     aria-label="Portrait of Kevin Gugelmann, drawn in text characters"


### PR DESCRIPTION
The ASCII portrait at the bottom of the homepage sat close to the CTA buttons above it. Its top margin goes from `mt-14 md:mt-16` to `mt-20 md:mt-24` to give the graphic more room.