### PR TITLE
Spell out the contact countdown messages

### DIFF
--- a/src/lib/views/ContactSection.svelte
+++ b/src/lib/views/ContactSection.svelte
@@ -44,11 +44,11 @@
     "I'm leaving",
     "Goodbye",
     "I'm going in...",
-    "3 Mississippi",
-    "2 Mississippi",
-    "1 Mississippi",
-    "0 Mississippi",
-    "-1 Mississippi",
+    "Three",
+    "Two",
+    "One",
+    "Zero",
+    "Minus One",
     "Got you there",
     "Cycling to i=0", // and the modulo below does exactly that
   ];


### PR DESCRIPTION
The contact section's cycling messages counted down as "3 Mississippi" through "-1 Mississippi". Those are now spelled out as "Three", "Two", "One", "Zero", "Minus One". All five are shorter than what they replace, so the row-33 width constraint noted above the list still holds.