### PR TITLE
Stop the homepage logging to the console.

### DIFF
--- a/src/lib/components/FloatingEssayImage.svelte
+++ b/src/lib/components/FloatingEssayImage.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { gsap } from "gsap";
-  import { onMount, onDestroy } from "svelte";
+  import { onDestroy } from "svelte";
 
   export let thumbnailSrc: string | null = null;
   export let essaySlug: string | null = null;
@@ -23,10 +23,14 @@
   $: cardOffsetX = -140; // Center the card horizontally on cursor
   $: cardOffsetY = isInTopHalf ? 60 : -(floatingImageHeight + 60); // Below cursor if top half, above if bottom half
 
-  onMount(() => {
-    // Hide it off-screen initially to prevent any flash at (0,0)
+  /* The card only enters the DOM once there is something to show, so there is
+     no element to park off-screen at mount time. Park it the moment it appears
+     instead, before the positioning block below ever runs. */
+  let parkedOffScreen = false;
+  $: if (containerElement && !parkedOffScreen) {
+    parkedOffScreen = true;
     gsap.set(containerElement, { x: -1000, y: -1000, opacity: 0 });
-  });
+  }
 
   // Main reactive logic for animations and positioning
   $: {
@@ -88,7 +92,9 @@
   }
 
   onDestroy(() => {
-    gsap.killTweensOf(containerElement);
+    if (containerElement) {
+      gsap.killTweensOf(containerElement);
+    }
   });
 </script>
 

--- a/src/lib/components/FloatingProjectImage.svelte
+++ b/src/lib/components/FloatingProjectImage.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { gsap } from "gsap";
-  import { onMount, onDestroy } from "svelte";
+  import { onDestroy } from "svelte";
   import Image from "$lib/components/Image.svelte";
   import type { ImageOptions } from "$lib/util/image";
 
@@ -25,10 +25,14 @@
   $: cardOffsetX = -160; // Center the card horizontally on cursor
   $: cardOffsetY = isInTopHalf ? 60 : -(floatingImageHeight + 60); // Below cursor if top half, above if bottom half
 
-  onMount(() => {
-    // Hide it off-screen initially to prevent any flash at (0,0)
+  /* The card only enters the DOM once there is something to show, so there is
+     no element to park off-screen at mount time. Park it the moment it appears
+     instead, before the positioning block below ever runs. */
+  let parkedOffScreen = false;
+  $: if (containerElement && !parkedOffScreen) {
+    parkedOffScreen = true;
     gsap.set(containerElement, { x: -1000, y: -1000, opacity: 0 });
-  });
+  }
 
   // Main reactive logic for animations and positioning
   $: {
@@ -90,7 +94,9 @@
   }
 
   onDestroy(() => {
-    gsap.killTweensOf(containerElement);
+    if (containerElement) {
+      gsap.killTweensOf(containerElement);
+    }
   });
 </script>
 
@@ -116,7 +122,8 @@
     /* Use transform for positioning instead of left/top */
     top: 0;
     left: 0;
-    /* Start with 0 opacity to prevent flash, onMount will move it off-screen */
+    /* Start with 0 opacity to prevent flash; it is parked off-screen as soon as
+       it mounts */
     opacity: 0;
   }
 

--- a/src/lib/views/HeroSection.svelte
+++ b/src/lib/views/HeroSection.svelte
@@ -224,7 +224,7 @@
       ) as unknown as HTMLElement[]) ?? []
     );
 
-    if (oldChars) {
+    if (oldChars && oldChars.length) {
       gsap.set(oldChars, { y: "0%" });
     }
     if (newCharsAll.length) {
@@ -266,8 +266,7 @@
           typeof window !== "undefined" ? window.innerWidth : screenWidth
         ) == BreakpointSizes.sm;
 
-      if (oldChars) {
-        console.log('isSmallNow1',Number(isSmallNow),isSmallNow)
+      if (oldChars && oldChars.length) {
         timeline.to(oldChars, {
           y: "-110%",
           duration: timings.oldCharsDuration[Number(isSmallNow)],
@@ -281,8 +280,9 @@
       ) as unknown as HTMLElement[];
 
       if (newChars && newChars.length) {
-        console.log('isSmallNow2',Number(isSmallNow),isSmallNow)
-        const newCharsPosition = oldChars ? `-=${timings.newCharsNegDelay[Number(isSmallNow)]}` : 0;
+        const newCharsPosition = oldChars?.length
+          ? `-=${timings.newCharsNegDelay[Number(isSmallNow)]}`
+          : 0;
         timeline.to(
           newChars,
           {

--- a/src/routes/roll/+page.svelte
+++ b/src/routes/roll/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { goto } from "$app/navigation";
+  import { dev } from "$app/environment";
   import { onMount } from "svelte";
   import { tick } from "svelte";
   import { gsap } from "gsap";
@@ -37,7 +38,11 @@
     // Reserved for future timers; keep cleanup centralized.
   }
 
+  /* Autoplay on this page fails in enough browser-specific ways that the trace
+     is worth keeping, but only where someone is watching it. */
   function logRoll(label: string, extra: Record<string, unknown> = {}) {
+    if (!dev) return;
+
     const nowMs =
       typeof performance !== "undefined" ? Math.round(performance.now()) : 0;
     const media = videoEl


### PR DESCRIPTION
The hero title swap had two leftover debug logs. The floating hover cards called `gsap.set` on their container in `onMount`, but that element only enters the DOM on the first hover, so every page load handed GSAP an undefined target twice; they now park off-screen the moment the element appears, which keeps the no-flash behaviour without the warning. Their `onDestroy` cleanup and the hero's `.char` queries are guarded the same way, so an empty or absent target can't reach GSAP either. Separately, `/roll` was tracing every media event to the console in production — that trace is genuinely useful for debugging autoplay, so it is gated on `dev` rather than deleted.

Verified with `svelte-check`: no errors in the four touched files. (`vite build` fails at prerender on a broken `/manifesto` link in essay content, but that reproduces identically on a clean tree.)