### PR TITLE
Reword the contact heading's second line.

### DIFF
--- a/scripts/generate-llms.mjs
+++ b/scripts/generate-llms.mjs
@@ -133,7 +133,7 @@ const formatDate = (date) => {
 
 // ===== HEADER BLOCK =====
 const headerBlock = `Kevin Gugelmann - Building good tech
-Product Owner at Revolut working on travel products. Technology is neutral; let's use it for net good.
+Product Owner at Revolut working on travel products. Technology is neutral; let's build good tech.
 
 Canonical: ${siteUrl}
 Call me: https://cal.com/kevgug/intro
@@ -174,7 +174,7 @@ ${projectDetails}
 
 ## Contact
 
-Technology is neutral. Let's use it for net good.
+Technology is neutral. Let's build good tech.
 
 - Built AI tooling at JPMorganChase and full-stack products at Freestyle (YC S24).
 - Studied Economics and Cognitive Science at the University of Chicago.

--- a/src/lib/views/ContactSection.svelte
+++ b/src/lib/views/ContactSection.svelte
@@ -357,12 +357,12 @@
 <div id="contact">
   <div>
     <h1 class="text-glacial-blue">
-      <!-- Each line breaks at the width where it stops fitting: 374px, 409px -->
-      <span class="flex flex-col gap-3.5 min-[410px]:gap-0">
+      <!-- Both lines break below 375px, where the longer of the two stops fitting -->
+      <span class="flex flex-col gap-3.5 min-[375px]:gap-0">
         <span class="hidden min-[375px]:inline">Technology is neutral.</span>
         <span class="min-[375px]:hidden">Technology<br>is neutral.</span>
-        <span class="hidden min-[410px]:inline">Let's use it for net good.</span>
-        <span class="min-[410px]:hidden">Let's use it for<br>net good.</span>
+        <span class="hidden min-[375px]:inline">Let's build good tech.</span>
+        <span class="min-[375px]:hidden">Let's build<br>good tech.</span>
       </span>
     </h1>
     <!-- Same card as /essays, so the two listings read as one thing -->


### PR DESCRIPTION
The contact heading's second line becomes "Let's build good tech." in place of "Let's use it for net good.", and the two `llms.txt` blurbs that repeat the line follow.

Each heading line carried its own breakpoint, tuned to the width where that line stops fitting. Measured against the Euclid Square Semibold metrics at 28px, the new line is 6px narrower than "Technology is neutral.", so the first line is now the binding one and both sit on its existing 375px breakpoint. Below that the line stacks as "Let's build / good tech."